### PR TITLE
Use non-deprecated MAP_ANONYMOUS

### DIFF
--- a/library/src/main/jni/trampoline.c
+++ b/library/src/main/jni/trampoline.c
@@ -117,7 +117,7 @@ int doInitHookCap(unsigned int cap) {
     }
     unsigned int allSize = trampolineSize * cap;
     unsigned char *buf = mmap(NULL, allSize, PROT_READ | PROT_WRITE | PROT_EXEC,
-                              MAP_ANON | MAP_PRIVATE, -1, 0);
+                              MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
     if (buf == MAP_FAILED) {
         LOGE("mmap failed, errno = %s", strerror(errno));
         return 1;


### PR DESCRIPTION
 *  MAP_ANON: Synonym for MAP_ANONYMOUS.  Deprecated.