### PR TITLE
Fix crash on Android 11

### DIFF
--- a/library/src/main/jni/HookMain.c
+++ b/library/src/main/jni/HookMain.c
@@ -162,13 +162,16 @@ static int replaceMethod(void *fromMethod, void *toMethod, int isBackup) {
     }
 
     // set the target method to native so that Android O wouldn't invoke it with interpreter
-    if (SDKVersion >= __ANDROID_API_O__) {
+    if(SDKVersion >= __ANDROID_API_O__) {
         int access_flags = getFlags(fromMethod);
         int old_flags = access_flags;
-        access_flags |= kAccNative;
         if (SDKVersion >= __ANDROID_API_Q__) {
             // On API 29 whether to use the fast path or not is cached in the ART method structure
             access_flags &= ~kAccFastInterpreterToInterpreterInvoke;
+        } else {
+            // We don't set kAccNative on R+ because they will try to load from real native method pointer instead of entry_point_from_quick_compiled_code_.
+            // Ref: https://cs.android.com/android/platform/superproject/+/android-11.0.0_r3:art/runtime/art_method.h;l=844;bpv=1;bpt=1
+            access_flags |= kAccNative;
         }
         setFlags(fromMethod, access_flags);
         LOGI("change access flags from 0x%x to 0x%x", old_flags, access_flags);


### PR DESCRIPTION
Fix #132 #130 (probably)
鉴于某谜语壬宁愿在issue里面讲故事也不发PR，那我自己研究下好了
Since **someone** figured out but won't send a PR, I'll do it.

From the crash trace, it tries to call `artQuickGenericJniTrampoline` and `art_quick_generic_jni_trampoline`, which will read `data_` from `ArtMethod` instead of `entry_point_from_quick_compiled_code_`, which will get null pointer and it won't properly throw a Exception. But according to the [Changelog](https://github.com/PAGalaxyLab/YAHFA/wiki/更新说明), it might cause hook fail on Android O+, but it seems working for me with even debug build.

Credits: @yujincheng08 