### PR TITLE
Clear kAccPreCompiled flag on R+

### DIFF
--- a/library/src/main/jni/HookMain.c
+++ b/library/src/main/jni/HookMain.c
@@ -12,6 +12,7 @@ static uint32_t OFFSET_access_flags_in_ArtMethod;
 static uint32_t kAccNative = 0x0100;
 static uint32_t kAccCompileDontBother = 0x01000000;
 static uint32_t kAccFastInterpreterToInterpreterInvoke = 0x40000000;
+static uint32_t kAccPreCompiled = 0x00200000;
 
 static jfieldID fieldArtMethod = NULL;
 
@@ -106,6 +107,9 @@ static void setNonCompilable(void *method) {
     uint32_t access_flags = getFlags(method);
     uint32_t old_flags = access_flags;
     access_flags |= kAccCompileDontBother;
+    if (SDKVersion >= __ANDROID_API_R__) {
+        access_flags &= ~kAccPreCompiled;
+    }
     setFlags(method, access_flags);
     LOGI("setNonCompilable: change access flags from 0x%x to 0x%x", old_flags, access_flags);
 


### PR DESCRIPTION
 * Since R, there is an additional check for IsCompilable() which
   is called IsPreCompiled(). Since we add kAccCompileDontBother
   flag unconditionally, we will likely see IsPreCompiled() return
   true when kAccPreCompiled is set, so IsCompilable() returns
   true and that is not what we want. Clear kAccPreCompiled
   flag to work around this issue. Note that this flag's value is
   modified again in the recent master branch, so we should
   review again when S is out.

 * All credits to https://github.com/yujincheng08 and
   https://github.com/canyie who first point out this issue.

   https://cs.android.com/android/platform/superproject/+/android-11.0.0_r1:art/runtime/art_method.h;l=240