### PR TITLE
Fix crash on some android12 devices(sansung Note20) and support android13

### DIFF
--- a/demoApp/src/main/java/lab/galaxy/yahfa/demoApp/Hook_Log_e.java
+++ b/demoApp/src/main/java/lab/galaxy/yahfa/demoApp/Hook_Log_e.java
@@ -1,0 +1,19 @@
+package lab.galaxy.yahfa.demoApp;
+
+import android.util.Log;
+
+public class Hook_Log_e {
+    public static String className = "android.util.Log";
+    public static String methodName = "e";
+    public static String methodSig = "(Ljava/lang/String;Ljava/lang/String;)I";
+
+    public static int hook(String tag, String msg) {
+        Log.w("HookTest", "in Log.e(): " + tag + ", " + msg);
+        return backup(tag, msg);
+    }
+
+    public static int backup(String tag, String msg) {
+        Log.w("HookTest", "Log.e() should not be here");
+        return 1;
+    }
+}

--- a/demoApp/src/main/java/lab/galaxy/yahfa/demoApp/MainActivity.java
+++ b/demoApp/src/main/java/lab/galaxy/yahfa/demoApp/MainActivity.java
@@ -6,6 +6,10 @@ import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 
+import java.lang.reflect.Method;
+
+import lab.galaxy.yahfa.HookMain;
+
 public class MainActivity extends Activity {
     private static final String TAG = "origin";
 
@@ -13,6 +17,19 @@ public class MainActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        findViewById(R.id.hookBtn).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                try {
+                    Method hook = Hook_Log_e.class.getDeclaredMethod("hook", String.class, String.class);
+                    Method backup = Hook_Log_e.class.getDeclaredMethod("backup", String.class, String.class);
+                    HookMain.findAndBackupAndHook(Log.class, Hook_Log_e.methodName, Hook_Log_e.methodSig, hook, backup);
+                } catch (NoSuchMethodException e) {
+                    e.printStackTrace();
+                }
+            }
+        });
 
         Button button = (Button) findViewById(R.id.button);
         button.setOnClickListener(new View.OnClickListener() {

--- a/demoApp/src/main/res/layout/activity_main.xml
+++ b/demoApp/src/main/res/layout/activity_main.xml
@@ -11,4 +11,12 @@
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
         android:text="Button" />
+
+    <Button
+        android:id="@+id/hookBtn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignStart="@+id/button"
+        android:layout_marginTop="200dp"
+        android:text="Start Hook" />
 </RelativeLayout>

--- a/library/src/main/jni/HookMain.c
+++ b/library/src/main/jni/HookMain.c
@@ -22,6 +22,7 @@ void Java_lab_galaxy_yahfa_HookMain_init(JNIEnv *env, jclass clazz, jint sdkVers
     jclass classExecutable;
     LOGI("init to SDK %d", sdkVersion);
     switch (sdkVersion) {
+        case __ANDROID_API_T__:
         case __ANDROID_API_S_L__:
         case __ANDROID_API_S__:
             kAccPreCompiled = 0x00800000;

--- a/library/src/main/jni/common.h
+++ b/library/src/main/jni/common.h
@@ -8,6 +8,11 @@
 #include <android/log.h>
 #include <stdint.h>
 
+// Android 13
+#ifndef __ANDROID_API_T__
+#define __ANDROID_API_T__ 33
+#endif
+
 // Android 12+
 #ifndef __ANDROID_API_S_L__
 #define __ANDROID_API_S_L__ 32


### PR DESCRIPTION
1. Calculate the offset of classlinker in Runtime in another way, it can support many android versions better include android 13.
2. Add api level to support  android13.